### PR TITLE
Add npm scripts for Truffle and update docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "truffle-plugin-verify": "^0.5.21"
   },
   "scripts": {
+    "compile": "truffle compile",
+    "migrate:testnet": "truffle migrate --network testnet",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -25,9 +25,9 @@ File which contains 12 secret mnemonic phrases of your hd wallet in SEED_PHRASE 
 
 ##### Deploy smart contact
  - ```npm install```
- - Copiling smart contract ```truffle compile```
- - Deploying smart contract - ```truffle migrate --network=testnet``` Choose network from ```truffle-config.js``` file.
- - Verify smart contract on bscscan/etherscan (API Keys are needed)- ```truffle run verify Airdrop@{ContractAddress} --network testnet```
+ - Compiling smart contract ```npm run compile```
+ - Deploying smart contract - ```npm run migrate:testnet``` Choose network from ```truffle-config.js``` file.
+ - Verify smart contract on bscscan/etherscan (API Keys are needed)- ```npx truffle run verify Airdrop@{ContractAddress} --network testnet```
  - Once smart contract is deployed and verified, you can interect it from bscscan/etherscan
 
 ##### Allowance


### PR DESCRIPTION
## Summary
- add `compile` and `migrate:testnet` npm scripts
- document using `npm run` and `npx truffle` instead of global installs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a66b0343f08333951452e889bcc5e5